### PR TITLE
fix click reporting arg specification

### DIFF
--- a/orpheum/translate.py
+++ b/orpheum/translate.py
@@ -436,18 +436,18 @@ class Translate:
 )
 @click.option(
     "--csv",
-    default=False,
+    default=None,
     help="Name of csv file to write with all sequence reads and " "their coding scores",
 )
 @click.option(
     "--parquet",
-    default=False,
+    default=None,
     help="Name of parquet file to write with all sequence reads and "
     "their coding scores",
 )
 @click.option(
     "--json-summary",
-    default=False,
+    default=None,
     help="Name of json file to write summarization of coding/"
     "noncoding/other categorizations, the "
     "min/max/mean/median/stddev of Jaccard scores, and other",
@@ -496,9 +496,9 @@ def cli(
     peptides_are_bloom_filter=False,
     jaccard_threshold=None,
     alphabet="protein",
-    csv=False,
-    parquet=False,
-    json_summary=False,
+    csv=None,
+    parquet=None,
+    json_summary=None,
     coding_nucleotide_fasta=None,
     noncoding_nucleotide_fasta=None,
     low_complexity_nucleotide_fasta=None,

--- a/tests/test_create_save_summary.py
+++ b/tests/test_create_save_summary.py
@@ -210,7 +210,7 @@ def test_generate_coding_summary(reads, data_folder, single_alphabet_ksize_true_
             "min": 0.0,
             "25%": 0.0,
             "50%": 0.0,
-            "75%": 0.05882352941176471,
+            "75%": 0.0588235294117647,
             "max": 1.0,
         },
         "categorization_counts": {

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -248,7 +248,7 @@ def test_cli_bad_jaccard_threshold_string(reads, peptide_fasta):
         cli, ["--jaccard-threshold", "beyonce", peptide_fasta, reads]
     )
     assert result.exit_code == 2
-    error_message = "beyonce is not a valid floating point value"
+    error_message = "'beyonce' is not a valid float"
     assert error_message in result.output
 
 


### PR DESCRIPTION
Closes #100.

Default values for several reporting file arguments were set to `False` instead of `None`, which led `click` to infer that these were supposed to take `boolean` type input. This PR changes those defaults to `None`.

Also fixes minor issues in two unrelated tests.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] Ensure the test suite passes with [pytest](https://docs.pytest.org/en/latest/) . (command to run: `pytest` or `make coverage` if you want to see which lines don't have tests yet)
 - [x] Make sure your code is linted and autoformatted using [black](https://github.com/psf/black) (`black . --check`).
